### PR TITLE
WIP: Sentinel artifacts

### DIFF
--- a/conf/synapse.sample.conf
+++ b/conf/synapse.sample.conf
@@ -29,7 +29,7 @@ Automation:
   internal_contact: <customer_id>
   debug_contact: <customer_id>
   #The regexes that are used to find tags within The Hive that are used for automation purposes
-  automation_regexes: 
+  automation_regexes:
     - 'uc-\w+-\d{3}\w{0,2}'
   #Logs the received webhooks in a different file. Can be useful for developping, troubleshooting and/or auditing
   log_webhooks: false
@@ -73,7 +73,7 @@ TheHive:
     sender_name: Notifications
 
 Cortex:
-   : false
+  enabled: false
   #Url to contact Cortex
   url: http://127.0.0.1:9002
   #The user from The Hive created for Synapse
@@ -157,10 +157,10 @@ QRadar:
   #Enable/disable the automation identifiers (such as Rule Id)
   extract_automation_identifiers: true
   #Fields to parse automation identifiers from. Which will be turned into tags
-  automation_fields: 
+  automation_fields:
     - rules
   #The regex used for the parsing
-  tag_regexes: 
+  tag_regexes:
     - 'uc-\w+-\d{3}\w{0,2}'
   # In case there you have a kb where the rule name can be appended to the url like so:
   # https://kb.url/use_cases/<uc_kb_name>
@@ -173,13 +173,13 @@ QRadar:
   #Optional configuration to configure timezone for the received timestamps. Default is local (of the server running synapse)
   #timezone: <timezone>
   observables_in_offense_type:
-    Hostname (custom): 
+    Hostname (custom):
       - regex: '(([\w\d-]+)\.?)((([\w\d]+)\.?)*\.([\w\d]+))'
         match_groups:
           0: fqdn
           3: domain
     MD5 Hash (custom): hash
-  
+
 
 Splunk:
   #Enable/disable the integration part of the module
@@ -214,7 +214,7 @@ MISP:
   enabled: false
   automation_enabled: false
   #A list of data types that are checked for when the feature is enable to automatically search for observables in QRadar
-  supported_datatypes: 
+  supported_datatypes:
     - "ip"
     - "domain"
     - "fqdn"
@@ -227,6 +227,8 @@ AzureSentinel:
   enabled: false
   #Endpoint used in the integration url
   synapse_endpoint: sentinel
+  #Import incident labels as TheHive tags?
+  import_tags: false
   #Your Office 365 tenant id where the service account/sentinel lives
   tenant_id: <tenant_id>
   #The id of the service account

--- a/conf/synapse.sample.conf
+++ b/conf/synapse.sample.conf
@@ -225,6 +225,8 @@ MISP:
 AzureSentinel:
   #Enable/disable the integration part of the module
   enabled: false
+  #Enable/disable the automation part of the module
+  automation_enabled: false
   #Endpoint used in the integration url
   synapse_endpoint: sentinel
   #Import incident labels as TheHive tags?
@@ -243,6 +245,12 @@ AzureSentinel:
   workspace: <workspace>
   #A case template to assign on alerts created for an incident
   case_template: Sentinel Incident
+  #Optional configuration to import Sentinel incident labels as TheHive tags? Default is false
+  # import_tags: true
+  #Optional configuration to configure timezone for the received timestamps. Default is local (of the server running synapse)
+  # timezone: Australia/Sydney
+  #Optional how far to lookback for updated incidents. Takes units in days (d) and hours (h). E.g. 1d, 20d, 5h
+  # lookback: 24h
 
 Lexsi:
   #Enable/disable the integration part of the module

--- a/modules/AzureSentinel/integration.py
+++ b/modules/AzureSentinel/integration.py
@@ -68,11 +68,12 @@ class Integration(Main):
             '|                         |               |\n' +
             '| ----------------------- | ------------- |\n' +
             '| **Start Time**          | ' + str(self.azureSentinelConnector.formatDate("description", incident['properties']['createdTimeUtc'])) + ' |\n' +
-            '| **incident ID**          | ' + str(incident['properties']['incidentNumber']) + ' |\n' +
+            '| **incident ID**         | ' + str(incident['properties']['incidentNumber']) + ' |\n' +
             '| **Description**         | ' + str(incident['properties']['description'].replace('\n', '')) + ' |\n' +
-            '| **incident Type**        | ' + str(incident['type']) + ' |\n' +
-            '| **incident Source**      | ' + str(incident['properties']['additionalData']['alertProductNames']) + ' |\n' +
-            '| **incident Status**      | ' + str(incident['properties']['status']) + ' |\n' +
+            '| **incident Type**       | ' + str(incident['type']) + ' |\n' +
+            '| **incident Source**     | ' + ', '.join(incident['properties']['additionalData'].get('alertProductNames', [])) + ' |\n' +
+            '| **incident Status**     | ' + str(incident['properties']['status']) + ' |\n' +
+            '| **Tactics**             | ' + ', '.join(incident['properties']['additionalData'].get('tactics', [])) + ' |\n' +
             '\n\n\n\n')
 
         return self.description
@@ -112,6 +113,14 @@ class Integration(Main):
             if entity['kind'] == "Account":
                 if 'isDomainJoined' in entity['properties']:
                     artifact['tags'].append('DomainJoined')
+                # If username is an email
+                if 'upnSuffix' in entity['properties']:
+                    artifact['data'] = f"{entity['properties']['accountName']}@{entity['properties']['upnSuffix']}"
+                    artifact['dataType'] = 'mail'
+                    yield artifact
+                    # Set type back to account
+                    artifact['dataType'] = entity_mapping.get(entity['kind'], 'other')
+
                 artifact['data'] = entity['properties']['accountName']
 
             elif entity['kind'] == "Malware":

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,3 +33,4 @@ urllib3==1.23
 werkzeug==0.14.1
 PyYAML==5.1.1
 redis==3.3.8
+msal


### PR DESCRIPTION
This PR adds entity extraction functionality. Set to WIP for discussion. It currently uses an undocumented preview API the Azure portal uses.

Notes:
- Extract all entity types with some special case handling
- Configurable option to add incident level labels in Sentinel as tags to TheHive
- Optionally configurable `AzureSentinel.lookback` on Sentinel getIncidents. Specify only grabbing incidents updated within X hours or days: 
- Handle some of the smaller changes between TH3 and TH4 webhooks
- Handle closing all Sentinel incidents when multiple alerts are linked in a case

Questions:
- What's the best way to deal with additional data. Currently I shove it in the message, but it doesn't look very nice. Would putting "{key}={value}" tags be desirable. An example of that data would be URL detonation results and final URL etc.